### PR TITLE
Remove content flash on page load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import './App.css';
 import { PicketSign } from './components/PicketSign';
 import { SignContent } from './types';
@@ -22,43 +22,51 @@ function App() {
     }
 
     // do nothing if there's already two actively face-up cards:
-    const faceUpCards = cards.filter(c => c.isFaceUp && !c.isMatched); // TODO: do we care about O(N) here? probably not
+    const faceUpCards = cards.filter((c) => c.isFaceUp && !c.isMatched); // TODO: do we care about O(N) here? probably not
     if (faceUpCards.length >= 2) {
       return;
     }
 
     // flip the card face-up:
-    const newCards = cards.map(c =>
+    const newCards = cards.map((c) =>
       c.id === card.id ? { ...c, isFaceUp: true } : c
     );
     setCards(newCards);
 
     // is this the second flip, and if so is it a match for the first?
-    const newFaceUpCards = newCards.filter(c => c.isFaceUp && !c.isMatched);
+    const newFaceUpCards = newCards.filter((c) => c.isFaceUp && !c.isMatched);
     if (newFaceUpCards.length === 2) {
       const [firstCard, secondCard] = newFaceUpCards;
       if (firstCard.value === secondCard.value) {
         // cards match, mark them as matched and keep them face up:
-        setCards(newCards.map(c =>
-          c.value === firstCard.value ? { ...c, isMatched: true } : c
-        ));
+        setCards(
+          newCards.map((c) =>
+            c.value === firstCard.value ? { ...c, isMatched: true } : c
+          )
+        );
       } else {
         // cards don't match, flip them back face-down after a delay:
         setTimeout(() => {
-          setCards(cards => cards.map(c =>
-            c.id === firstCard.id || c.id === secondCard.id
-              ? { ...c, isFaceUp: false }
-              : c
-          ));
+          setCards((cards) =>
+            cards.map((c) =>
+              c.id === firstCard.id || c.id === secondCard.id
+                ? { ...c, isFaceUp: false }
+                : c
+            )
+          );
         }, 1000);
       }
     }
   };
 
   return (
-    <div id='game'>
-      {cards.map(card => (
-        <div className='card' key={card.id} onClick={() => handleCardClick(card)}>
+    <div id="game">
+      {cards.map((card) => (
+        <div
+          className="card"
+          key={card.id}
+          onClick={() => handleCardClick(card)}
+        >
           <PicketSign content={card.value} isFaceUp={card.isFaceUp} />
         </div>
       ))}
@@ -69,23 +77,28 @@ function App() {
 export default App;
 
 function getInitialCards() {
-  const initialCards = [...CARD_VALUES, ...CARD_VALUES].map(
-    (value, id) => ({ value, id, isFaceUp: false, isMatched: false })
-  );
+  const initialCards = [...CARD_VALUES, ...CARD_VALUES].map((value, id) => ({
+    value,
+    id,
+    isFaceUp: false,
+    isMatched: false
+  }));
 
   // https://stackoverflow.com/questions/48083353/i-want-to-know-how-to-shuffle-an-array-in-typescript
-  let currentIndex = initialCards.length, randomIndex;
+  let currentIndex = initialCards.length,
+    randomIndex;
 
   // While there remain elements to shuffle.
   while (currentIndex != 0) {
-
     // Pick a remaining element.
     randomIndex = Math.floor(Math.random() * currentIndex);
     currentIndex--;
 
     // And swap it with the current element.
     [initialCards[currentIndex], initialCards[randomIndex]] = [
-      initialCards[randomIndex], initialCards[currentIndex]];
+      initialCards[randomIndex],
+      initialCards[currentIndex]
+    ];
   }
 
   return initialCards;

--- a/src/components/PicketSign/PicketSign.css
+++ b/src/components/PicketSign/PicketSign.css
@@ -14,7 +14,7 @@
   transform-style: preserve-3d;
 }
 
-.face-up {
+.face-down {
   transform: rotateY(180deg);
 }
 
@@ -26,7 +26,7 @@
   width: 100%;
 }
 
-.back-container {
+.front-container {
   transform: rotateY(180deg);
 }
 
@@ -35,12 +35,6 @@
   position: absolute;
   height: 100%;
   width: 100%;
-}
-
-.sign-post {
-  height: 100%;
-  width: 100%;
-  position: relative;
 }
 
 img.sign-image {

--- a/src/components/PicketSign/index.tsx
+++ b/src/components/PicketSign/index.tsx
@@ -1,8 +1,14 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { SignContent } from '../../types';
 import './PicketSign.css';
 
-export const PicketSign = ({ content, isFaceUp }: { content: SignContent, isFaceUp: boolean }) => {
+export const PicketSign = ({
+  content,
+  isFaceUp
+}: {
+  content: SignContent;
+  isFaceUp: boolean;
+}) => {
   const containerClass = useMemo(
     () => (isFaceUp ? 'container face-down' : 'container face-up'),
     [isFaceUp]
@@ -11,29 +17,27 @@ export const PicketSign = ({ content, isFaceUp }: { content: SignContent, isFace
 
   return (
     <div className={containerClass}>
-      <div className="front-container">
-        <div className="sign-post">
-          <img
-            className="sign-image"
-            src="/assets/picket-sign/picket-sign-face-up.png"
-            onDragStart={(e) => e.preventDefault()}
-          />
-          <div className="content-container">
-            <img
-              className="content"
-              src={imageSrc}
-              alt={content}
-              onDragStart={(e) => e.preventDefault()}
-            />
-          </div>
-        </div>
-      </div>
       <div className="back-container">
         <img
           className="sign-image"
           src="/assets/picket-sign/picket-sign-face-down.png"
           onDragStart={(e) => e.preventDefault()}
         />
+      </div>
+      <div className="front-container">
+        <img
+          className="sign-image"
+          src="/assets/picket-sign/picket-sign-face-up.png"
+          onDragStart={(e) => e.preventDefault()}
+        />
+        <div className="content-container">
+          <img
+            className="content"
+            src={imageSrc}
+            alt={content}
+            onDragStart={(e) => e.preventDefault()}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Other than my autoformatter moving some things, all this PR does is switch the order in which the front and back of a picket sign are rendered. Rendering the back of the picket sign first (when we know the back will be displayed first anyways) prevents a flash of the card front on page load, briefly revealing the card's contents.