### PR TITLE
start the timer after first click

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,29 @@
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install and Build
+        if: github.event.action != 'closed' # You might want to skip the build if the PR has been closed
+        run: |
+          npm install
+          npm run build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./dist/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import './App.css';
 import { PicketSign } from './components/PicketSign';
 import { Game, NewGame } from './game';
@@ -11,9 +11,14 @@ function App() {
   const [game, setGame] = useState<Game>(NewGame());
   const [duration, setDuration] = useState('0m 0s');
 
+  const gameRef = useRef<Game>();
+  gameRef.current = game;
+
   useEffect(() => {
     const interval = setInterval(() => {
-      setDuration(game.getDuration());
+      if (gameRef.current) {
+        setDuration(gameRef.current.getDuration());
+      }
     }, 1000);
 
     return () => clearInterval(interval);

--- a/src/game.ts
+++ b/src/game.ts
@@ -14,7 +14,7 @@ interface GameData {
 }
 
 const DefaultGameData = {
-    start: new Date(),
+    start: null,
     end: null,
     score: 0,
     attempts: 0,
@@ -29,6 +29,14 @@ export function NewGame(game: GameData = DefaultGameData): Game{
             });
         },
         handleClick(): Game {
+            //mark the start time after the first click
+            if (game.attempts === 0) {
+                return NewGame({
+                    ...game,
+                    start: new Date(),
+                    attempts: 1
+                })
+            }
             return NewGame({
                 ...game,
                 attempts: game.attempts + 1,


### PR DESCRIPTION
Originally the timer was starting as soon as the app loaded. Now, the timer won't start until the player clicks their first card to flip, so players won't feel rushed when the game loads or have to reload the window when they are actually ready to play.