### PR TITLE
Don’t increment “Picket signs flipped” count if click is no-op

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,49 +1,26 @@
-name: Deploy
-
+name: Build and Deploy
 on:
   push:
     branches:
       - main
-
+permissions:
+  contents: write
 jobs:
-  build:
-    name: Build
+  build-and-deploy:
+    concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        run: |
+          npm ci
+          npm run build
 
-      - name: Install dependencies
-        uses: bahmutov/npm-install@v1
-
-      - name: Build project
-        run: npm run build
-
-      - name: Upload production-ready build files
-        uses: actions/upload-artifact@v3
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          name: production-files
-          path: ./dist
-
-  deploy:
-    name: Deploy
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: production-files
-          path: ./dist
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          folder: dist # The folder the action should deploy.
+          force: no # leave CNAME file in place
+          clean-exclude: pr-preview/ # don't blow away preview envs

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,8 @@ function App() {
       return;
     }
 
+    setGame(game.handleClick());
+
     // flip the card face-up:
     const newCards = cards.map((c) =>
       c.id === card.id ? { ...c, isFaceUp: true } : c
@@ -78,7 +80,6 @@ function App() {
               className="card"
               key={card.id}
               onClick={() => {
-                setGame(game.handleClick());
                 handleCardClick(card);
               }}
             >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,9 +79,7 @@ function App() {
             <div
               className="card"
               key={card.id}
-              onClick={() => {
-                handleCardClick(card);
-              }}
+              onClick={() => handleCardClick(card)}
             >
               <PicketSign card={card} />
             </div>
@@ -95,7 +93,7 @@ function App() {
           </p>
           <div className="row">
             <p className="attempts">
-              <strong>Cards flipped:</strong> {game.getAttempts()}
+              <strong>Picket signs flipped:</strong> {game.getAttempts()}
             </p>
             <p className="score">
               <strong>Matches:</strong> {game.getScore()}


### PR DESCRIPTION
`game.handleClick()`, which updates game state, was being called before checking whether the clicked card was already flipped or already matched and therefore should’ve been a no-op. This fixes that.